### PR TITLE
Drop all tables if they exist first

### DIFF
--- a/src/main/resources/createTables.sql
+++ b/src/main/resources/createTables.sql
@@ -1,4 +1,6 @@
 -- note that order is important due to fk constraints
+DROP TABLE IF EXISTS `talking_points_scopes`, `requests`, `reminders`, `reminder_history`, `district_scripts`, `talking_points`, `themes`, `district_offices`, `calls`, `callers_contact_methods`, `callers`, `call_targets`, `admins_districts`, `admins`, `districts`, `addresses`;
+
 
 -- Create syntax for TABLE 'admins'
 CREATE TABLE `admins` (


### PR DESCRIPTION
Makes it easier to rebuild your database

Note that I've included the table 'addresses' - this doesn't appear to be in the latest DDL but I figure if it used to exist, we might as well include it in the drops.