### PR TITLE
single rep states were showing up wrong. this fixes them

### DIFF
--- a/src/main/java/com/ccl/grandcanyon/ReminderService.java
+++ b/src/main/java/com/ccl/grandcanyon/ReminderService.java
@@ -262,7 +262,7 @@ public class ReminderService {
 
       Message reminderMessage = new Message();
 
-      String legislatorTitle = targetDistrict.getNumber() > 0 ? "Rep." : "Senator";
+      String legislatorTitle = targetDistrict.getNumber() >= 0 ? "Rep." : "Senator";
 
       reminderMessage.setBody("It's your day to call " + legislatorTitle + " " + targetDistrict.getRepLastName() +
           ". http://" + callInPageUrl);


### PR DESCRIPTION
For example, AK-0 is a representative, not a Senator. Senators are only -1 and -2