### PR TITLE
Federal holidays support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
       <artifactId>postmark</artifactId>
       <version>1.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.26</version>
+    </dependency>
     <!-- [END gae_flex_mysql_dependencies] -->
   </dependencies>
   <build>

--- a/src/main/java/com/ccl/grandcanyon/Calls.java
+++ b/src/main/java/com/ccl/grandcanyon/Calls.java
@@ -70,7 +70,7 @@ public class Calls {
       }
 
       // see if a call was already recorded for this tracking Id and districtId
-      LocalDateTime callDateTime = reminder.getLastReminderTimestamp().toLocalDateTime();
+      LocalDateTime callDateTime = reminder.getLastReminderTimestamp().toLocalDateTime(); //TODO: should this be OffsetDateTime or Instant?
       PreparedStatement query = conn.prepareStatement(SQL_SEARCH_CALL);
       query.setInt(1, reminder.getCallerId());
       query.setInt(2, callDateTime.getMonthValue());

--- a/src/main/java/com/ccl/grandcanyon/HolidayService.java
+++ b/src/main/java/com/ccl/grandcanyon/HolidayService.java
@@ -2,8 +2,11 @@ package com.ccl.grandcanyon;
 
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -13,31 +16,28 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class HolidayService {
-    private final static String HOLIDAY_LIST_FILEPATH = "./config/holidays.yaml";
+    private final static String HOLIDAY_LIST_URL = "https://cclcalls.org/config/holidays.yaml";
     private final static Logger logger = Logger.getLogger(HolidayService.class.getName());
-    private final List<LocalDate> holidays;
+    private List<LocalDate> holidays;
     private static HolidayService instance;
 
-    // Allowed to call multiple times to update `holidays`
+    private HolidayService() {
+        logger.info("Init HolidayService");
+        loadHolidays();
+    }
+
     public static void init(){
+        assert(instance == null);
         instance = new HolidayService();
+    }
+
+    public void refresh(){
+        loadHolidays();
     }
 
     public static HolidayService getInstance() {
         assert(instance != null);
         return instance;
-    }
-
-    private HolidayService() {
-        logger.info("Init HolidayService");
-        try {
-            Yaml yaml = new Yaml();
-            InputStream stream = new FileInputStream(HOLIDAY_LIST_FILEPATH);
-            List<Date> holidayDates = yaml.load(stream);
-            holidays = holidayDates.stream().map(it -> it.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to load holiday yaml file: " + e.getLocalizedMessage());
-        }
     }
 
     public Boolean isHoliday(OffsetDateTime offsetDateTime) {
@@ -50,5 +50,25 @@ public class HolidayService {
 
     public List<LocalDate> getHolidays() {
         return holidays;
+    }
+
+    private void loadHolidays(){
+        try {
+            Yaml yaml = new Yaml();
+            String holidaysYaml = getHolidaysYaml();
+            List<Date> holidayDates = yaml.load(holidaysYaml);
+            holidays = holidayDates.stream().map(it -> it.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to load holiday yaml file: " + e.getLocalizedMessage());
+        }
+    }
+
+    private String getHolidaysYaml() throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(HOLIDAY_LIST_URL))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
     }
 }

--- a/src/main/java/com/ccl/grandcanyon/HolidayService.java
+++ b/src/main/java/com/ccl/grandcanyon/HolidayService.java
@@ -23,7 +23,7 @@ public class HolidayService {
 
     private HolidayService() {
         logger.info("Init HolidayService");
-        loadHolidays();
+        refresh();
     }
 
     public static void init(){
@@ -32,7 +32,14 @@ public class HolidayService {
     }
 
     public void refresh(){
-        loadHolidays();
+        try {
+            Yaml yaml = new Yaml();
+            String holidaysYaml = getHolidaysYaml();
+            List<Date> holidayDates = yaml.load(holidaysYaml);
+            holidays = holidayDates.stream().map(it -> it.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to load holiday yaml file: " + e.getLocalizedMessage());
+        }
     }
 
     public static HolidayService getInstance() {
@@ -50,17 +57,6 @@ public class HolidayService {
 
     public List<LocalDate> getHolidays() {
         return holidays;
-    }
-
-    private void loadHolidays(){
-        try {
-            Yaml yaml = new Yaml();
-            String holidaysYaml = getHolidaysYaml();
-            List<Date> holidayDates = yaml.load(holidaysYaml);
-            holidays = holidayDates.stream().map(it -> it.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to load holiday yaml file: " + e.getLocalizedMessage());
-        }
     }
 
     private String getHolidaysYaml() throws IOException, InterruptedException {

--- a/src/main/java/com/ccl/grandcanyon/HolidayService.java
+++ b/src/main/java/com/ccl/grandcanyon/HolidayService.java
@@ -1,0 +1,54 @@
+package com.ccl.grandcanyon;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class HolidayService {
+    private final static String HOLIDAY_LIST_FILEPATH = "./config/holidays.yaml";
+    private final static Logger logger = Logger.getLogger(HolidayService.class.getName());
+    private final List<LocalDate> holidays;
+    private static HolidayService instance;
+
+    // Allowed to call multiple times to update `holidays`
+    public static void init(){
+        instance = new HolidayService();
+    }
+
+    public static HolidayService getInstance() {
+        assert(instance != null);
+        return instance;
+    }
+
+    private HolidayService() {
+        logger.info("Init HolidayService");
+        try {
+            Yaml yaml = new Yaml();
+            InputStream stream = new FileInputStream(HOLIDAY_LIST_FILEPATH);
+            List<Date> holidayDates = yaml.load(stream);
+            holidays = holidayDates.stream().map(it -> it.toInstant().atOffset(ZoneOffset.UTC).toLocalDate()).collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to load holiday yaml file: " + e.getLocalizedMessage());
+        }
+    }
+
+    public Boolean isHoliday(OffsetDateTime offsetDateTime) {
+       return isHoliday(offsetDateTime.toLocalDate());
+    }
+
+    public Boolean isHoliday(LocalDate localDate) {
+        return holidays.indexOf(localDate) != -1;
+    }
+
+    public List<LocalDate> getHolidays() {
+        return holidays;
+    }
+}

--- a/src/main/java/com/ccl/grandcanyon/HolidayService.java
+++ b/src/main/java/com/ccl/grandcanyon/HolidayService.java
@@ -26,11 +26,6 @@ public class HolidayService {
         refresh();
     }
 
-    public static void init(){
-        assert(instance == null);
-        instance = new HolidayService();
-    }
-
     public void refresh(){
         try {
             Yaml yaml = new Yaml();
@@ -43,7 +38,9 @@ public class HolidayService {
     }
 
     public static HolidayService getInstance() {
-        assert(instance != null);
+        if(instance == null) {
+            instance = new HolidayService();
+        }
         return instance;
     }
 

--- a/src/main/java/com/ccl/grandcanyon/ReminderService.java
+++ b/src/main/java/com/ccl/grandcanyon/ReminderService.java
@@ -177,7 +177,6 @@ public class ReminderService {
     }
 
     try {
-      HolidayService.init();
       this.holidayService = HolidayService.getInstance();
     }
     catch (Exception e) {

--- a/src/main/java/com/ccl/grandcanyon/ReminderService.java
+++ b/src/main/java/com/ccl/grandcanyon/ReminderService.java
@@ -154,7 +154,7 @@ public class ReminderService {
 
     try {
       this.smsDeliveryService = (DeliveryService)Class.forName(
-          config.getProperty(SMS_DELIVERY_SERVICE)).newInstance();
+          config.getProperty(SMS_DELIVERY_SERVICE)).getDeclaredConstructor().newInstance();
       this.smsDeliveryService.init(config);
     }
     catch (Exception e) {
@@ -164,7 +164,7 @@ public class ReminderService {
 
     try {
       this.emailDeliveryService = (DeliveryService)Class.forName(
-          config.getProperty(EMAIL_DELIVERY_SERVICE)).newInstance();
+          config.getProperty(EMAIL_DELIVERY_SERVICE)).getDeclaredConstructor().newInstance();
       this.emailDeliveryService.init(config);
     }
     catch (Exception e) {

--- a/src/main/java/com/ccl/grandcanyon/ReminderService.java
+++ b/src/main/java/com/ccl/grandcanyon/ReminderService.java
@@ -47,8 +47,8 @@ public class ReminderService {
   private final static String SQL_UPDATE_REMINDER =
       "UPDATE reminders SET " +
           Reminder.LAST_REMINDER_TIMESTAMP + " = ?, " +
-          Reminder.TRACKING_ID + " = ? " +
-          Reminder.REMINDER_YEAR + " = ? " +
+          Reminder.TRACKING_ID + " = ?, " +
+          Reminder.REMINDER_YEAR + " = ?, " +
           Reminder.REMINDER_MONTH + " = ? " +
           "WHERE " + Reminder.CALLER_ID + " = ?";
 
@@ -337,9 +337,9 @@ public class ReminderService {
     int idx = 1;
     update.setTimestamp(idx++, timestamp);
     update.setString(idx++, reminderStatus.getTrackingId());
-    update.setInt(idx++, reminderStatus.getCaller().getCallerId());
     update.setInt(idx++, reminderDate.getYear());
-    update.setInt(idx, reminderDate.getMonth());
+    update.setInt(idx++, reminderDate.getMonth());
+    update.setInt(idx, reminderStatus.getCaller().getCallerId());
     update.executeUpdate();
 
     // add history record

--- a/src/main/java/com/ccl/grandcanyon/Reminders.java
+++ b/src/main/java/com/ccl/grandcanyon/Reminders.java
@@ -2,6 +2,7 @@ package com.ccl.grandcanyon;
 
 import com.ccl.grandcanyon.types.Admin;
 import com.ccl.grandcanyon.types.Caller;
+import com.ccl.grandcanyon.types.ReminderDate;
 import com.ccl.grandcanyon.types.ReminderHistory;
 import com.ccl.grandcanyon.types.ReminderStatus;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -15,6 +16,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -44,7 +46,8 @@ public class Reminders {
     try {
       Caller caller = Callers.retrieveById(conn, callerId);
       checkPermissions(caller.getDistrictId(), "send a call notification");
-      ReminderStatus status = ReminderService.getInstance().sendReminder(conn, caller);
+      ReminderDate reminderDate = new ReminderDate(LocalDate.now());
+      ReminderStatus status = ReminderService.getInstance().sendReminder(conn, caller, reminderDate);
       return Response.ok(BooleanNode.valueOf(status.success())).build();
     }
     finally {

--- a/src/main/java/com/ccl/grandcanyon/deliverymethod/PostmarkService.java
+++ b/src/main/java/com/ccl/grandcanyon/deliverymethod/PostmarkService.java
@@ -38,7 +38,7 @@ public class PostmarkService implements DeliveryService {
         apiClient = Postmark.getApiClient(apiKey);
 
         // Postmark rate limit
-        messageQueue = new LinkedList();
+        messageQueue = new LinkedList<>();
         this.sendingTask = Executors.newSingleThreadScheduledExecutor().
                 scheduleAtFixedRate(new PostmarkSender(), 10, SEND_FREQUENCY, TimeUnit.SECONDS);
     }

--- a/src/main/java/com/ccl/grandcanyon/types/Caller.java
+++ b/src/main/java/com/ccl/grandcanyon/types/Caller.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/ccl/grandcanyon/types/Reminder.java
+++ b/src/main/java/com/ccl/grandcanyon/types/Reminder.java
@@ -92,11 +92,16 @@ public class Reminder {
     this.reminderMonth = reminderMonth;
   }
 
-  public Boolean isDueToBeSent(ReminderDate reminderDate) {
-    assert(reminderDate != null);
+  public Boolean hasBeenSent(ReminderDate reminderDate) {
+    assert (reminderDate != null);
+    // This will only be null if a reminder has never been sent
     if (getLastReminderTimestamp() == null) {
-      return true;
+      return false;
     }
-    return getReminderYear() != reminderDate.getYear() || getReminderMonth() != reminderDate.getMonth();
+
+    // Note that REMINDER_YEAR and REMINDER_MONTH are updated when the reminder is sent,
+    // so this won't result in duplicate reminders being sent
+    return reminderDate.getYear() < getReminderYear() ||
+            reminderDate.getYear() == getReminderYear() && reminderDate.getMonth() < getReminderMonth();
   }
 }

--- a/src/main/java/com/ccl/grandcanyon/types/Reminder.java
+++ b/src/main/java/com/ccl/grandcanyon/types/Reminder.java
@@ -13,11 +13,18 @@ public class Reminder {
   public static final String SECOND_REMINDER_SENT = "second_reminder_timestamp";
   public static final String TRACKING_ID = "tracking_id";
 
+  // These are the year/month that the reminder is for and don't necessarily reflect
+  // the reminder timestamps
+  public static final String REMINDER_YEAR = "reminder_year";
+  public static final String REMINDER_MONTH = "reminder_month";
+
   private int callerId;
   private int dayOfMonth;
   private Timestamp lastReminderTimestamp;
   private Timestamp secondReminderTimestamp;
   private String trackingId;
+  private int reminderYear;
+  private int reminderMonth;
 
   public Reminder(ResultSet rs) throws SQLException {
     this.callerId = rs.getInt(CALLER_ID);
@@ -25,6 +32,8 @@ public class Reminder {
     this.lastReminderTimestamp = rs.getTimestamp(LAST_REMINDER_TIMESTAMP);
     this.secondReminderTimestamp = rs.getTimestamp(SECOND_REMINDER_SENT);
     this.trackingId = rs.getString(TRACKING_ID);
+    this.reminderYear = rs.getInt(REMINDER_YEAR);
+    this.reminderMonth = rs.getInt(REMINDER_MONTH);
   }
 
   public int getCallerId() {
@@ -65,5 +74,29 @@ public class Reminder {
 
   public void setTrackingId(String trackingId) {
     this.trackingId = trackingId;
+  }
+
+  public int getReminderYear() {
+    return reminderYear;
+  }
+
+  public void setReminderYear(int reminderYear) {
+    this.reminderYear = reminderYear;
+  }
+
+  public int getReminderMonth() {
+    return reminderMonth;
+  }
+
+  public void setReminderMonth(int reminderMonth) {
+    this.reminderMonth = reminderMonth;
+  }
+
+  public Boolean isDueToBeSent(ReminderDate reminderDate) {
+    assert(reminderDate != null);
+    if (getLastReminderTimestamp() == null) {
+      return true;
+    }
+    return getReminderYear() != reminderDate.getYear() || getReminderMonth() != reminderDate.getMonth();
   }
 }

--- a/src/main/java/com/ccl/grandcanyon/types/Reminder.java
+++ b/src/main/java/com/ccl/grandcanyon/types/Reminder.java
@@ -102,6 +102,6 @@ public class Reminder {
     // Note that REMINDER_YEAR and REMINDER_MONTH are updated when the reminder is sent,
     // so this won't result in duplicate reminders being sent
     return reminderDate.getYear() < getReminderYear() ||
-            reminderDate.getYear() == getReminderYear() && reminderDate.getMonth() < getReminderMonth();
+            reminderDate.getYear() == getReminderYear() && reminderDate.getMonth() <= getReminderMonth();
   }
 }

--- a/src/main/java/com/ccl/grandcanyon/types/ReminderDate.java
+++ b/src/main/java/com/ccl/grandcanyon/types/ReminderDate.java
@@ -53,6 +53,11 @@ public class ReminderDate {
         return Objects.hash(year, month, day);
     }
 
+    @Override
+    public String toString() {
+        return year.toString() + "-" + month.toString() + "-" + day.toString();
+    }
+
     public static class Builder {
         Integer year;
         Integer month;

--- a/src/main/java/com/ccl/grandcanyon/types/ReminderDate.java
+++ b/src/main/java/com/ccl/grandcanyon/types/ReminderDate.java
@@ -1,0 +1,86 @@
+package com.ccl.grandcanyon.types;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Objects;
+
+public class ReminderDate {
+    // Since a caller's call day might not exist in a given month, ReminderDate is used to represent
+    // the date that a reminder is for, but not necessarily sent on.
+    // e.g. This class can represent the reminder date Feb 30, which might be sent on Feb 28.
+
+    public final static Integer MIN_DAY = 1;
+    public final static Integer MAX_DAY = 31;
+
+    Integer year;
+    Integer month;
+    Integer day; // Doesn't have to be a valid day in this year/month
+
+    private ReminderDate(Builder builder) {
+        this.year = builder.year;
+        this.month = builder.month;
+        this.day = builder.day;
+    }
+
+    public ReminderDate(LocalDate date) {
+        this.year = date.getYear();
+        this.day = date.getDayOfMonth();
+        this.month = date.getMonth().getValue();
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public Integer getMonth() {
+        return month;
+    }
+
+    public Integer getDay() {
+        return day;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReminderDate reminderDate = (ReminderDate) o;
+        return year.equals(reminderDate.year) && month.equals(reminderDate.month) && day.equals(reminderDate.day);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(year, month, day);
+    }
+
+    public static class Builder {
+        Integer year;
+        Integer month;
+        Integer day; // Doesn't have to be a valid day in this year/month
+
+        public Builder year(Integer year) {
+            this.year = year;
+            return this;
+        }
+
+        public Builder month(Integer month) {
+            this.month = month;
+            return this;
+        }
+
+        public Builder month(Month month) {
+            this.month = month.getValue();
+            return this;
+        }
+
+        public Builder day(Integer day) {
+            this.day = day;
+            return this;
+        }
+
+        public ReminderDate build() {
+            return new ReminderDate(this);
+        }
+    }
+}
+

--- a/src/main/java/com/ccl/grandcanyon/types/ReminderDate.java
+++ b/src/main/java/com/ccl/grandcanyon/types/ReminderDate.java
@@ -12,9 +12,9 @@ public class ReminderDate {
     public final static Integer MIN_DAY = 1;
     public final static Integer MAX_DAY = 31;
 
-    Integer year;
-    Integer month;
-    Integer day; // Doesn't have to be a valid day in this year/month
+    private Integer year;
+    private Integer month;
+    private Integer day; // Doesn't have to be a valid day in this year/month
 
     private ReminderDate(Builder builder) {
         this.year = builder.year;
@@ -59,9 +59,9 @@ public class ReminderDate {
     }
 
     public static class Builder {
-        Integer year;
-        Integer month;
-        Integer day; // Doesn't have to be a valid day in this year/month
+        private Integer year;
+        private Integer month;
+        private Integer day; // Doesn't have to be a valid day in this year/month
 
         public Builder year(Integer year) {
             this.year = year;

--- a/src/main/resources/createTables.sql
+++ b/src/main/resources/createTables.sql
@@ -178,6 +178,8 @@ CREATE TABLE `reminders` (
   `last_reminder_timestamp` datetime DEFAULT NULL,
   `second_reminder_timestamp` datetime DEFAULT NULL,
   `tracking_id` varchar(32) DEFAULT NULL,
+  `reminder_year` int(11) DEFAULT NULL,
+  `reminder_month` int(11) DEFAULT NULL,
   PRIMARY KEY (`caller_id`),
   CONSTRAINT `reminders_ibfk_1` FOREIGN KEY (`caller_id`) REFERENCES `callers` (`caller_id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
resolves #11 
2 new columns have been added to the `reminders` table.
```SQL
ALTER TABLE `core`.`reminders` 
ADD COLUMN `reminder_year` INT(11) DEFAULT NULL AFTER `tracking_id`,
ADD COLUMN `reminder_month` INT(11) DEFAULT NULL AFTER `reminder_year`
```

I manually tested holidays and days off that fall at the end of the month, but I'm open to the idea of adding unit tests.
Note that these changes assume that reminders were sent on any previous business day e.g. if the service stops running for a few business days then starts back up again, this won't send reminders for the days that were missed. I did it this way because it already behaved like this.