### PR TITLE
removed private ctor from PostmarkService

### DIFF
--- a/src/main/java/com/ccl/grandcanyon/deliverymethod/PostmarkService.java
+++ b/src/main/java/com/ccl/grandcanyon/deliverymethod/PostmarkService.java
@@ -31,8 +31,6 @@ public class PostmarkService implements DeliveryService {
     private ScheduledFuture sendingTask;
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
-    private PostmarkService(){}
-
     @Override
     public void init(Properties config) {
         String apiKey = config.getProperty(API_KEY_PROP);


### PR DESCRIPTION
I accidentally left this in when I was messing around with refactoring it. It's currently causing an error when the ReminderService tries to construct it!