### PR TITLE
Require login to get caller info

### DIFF
--- a/src/main/java/com/ccl/grandcanyon/Callers.java
+++ b/src/main/java/com/ccl/grandcanyon/Callers.java
@@ -198,7 +198,6 @@ public class Callers {
   @GET
   @Path("{callerId}")
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed(GCAuth.ANONYMOUS)
   public Response getById(@PathParam("callerId") int callerId)
       throws SQLException {
 


### PR DESCRIPTION
The API should require login before revealing a caller's personal information. I made a one-line change that seems to fix this security hole. But I don't really understand the authentication system, so I'm not at all sure this is correct — please check.