### PR TITLE
Add migration file for adding notes column to callers table.

### DIFF
--- a/migrations/v001__add_caller_notes.sql
+++ b/migrations/v001__add_caller_notes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE callers ADD COLUMN notes varchar(10000);

--- a/run.sh
+++ b/run.sh
@@ -30,4 +30,8 @@ init-db() {
   setup-dummy-data
 }
 
+start() {
+  mvn clean jetty:run
+}
+
 "$@"


### PR DESCRIPTION
Also add ./run.sh start command.

This migration should be safe to run whenever, since the notes column defaults to null when new callers are inserted.