### PR TITLE
Fixes null timezone

### DIFF
--- a/src/main/java/com/ccl/grandcanyon/Districts.java
+++ b/src/main/java/com/ccl/grandcanyon/Districts.java
@@ -172,7 +172,7 @@ public class Districts {
       statement.setString(idx++, district.getInfo());
       String status = district.getStatus() == null ? null : district.getStatus().name();
       statement.setString(idx++, status);
-      statement.setString(idx++, district.getTimeZone());
+      statement.setString(idx++, district.getTimeZone() == null ? oldDistrict.getTimeZone() : district.getTimeZone());
       statement.setInt(idx, districtId);
       statement.executeUpdate();
 


### PR DESCRIPTION
A bug was introduced that caused time zone to be set to null if the field was not included in PUT requests to /districts. This fixes that.