### PR TITLE
Adds the option to delegate script writing to ccl staff at the district level

### DIFF
--- a/db/migrations/v005_script_delegation.sql
+++ b/db/migrations/v005_script_delegation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE districts ADD COLUMN `delegate_script` tinyint(1) NOT NULL DEFAULT 0;

--- a/src/main/java/com/ccl/grandcanyon/Districts.java
+++ b/src/main/java/com/ccl/grandcanyon/Districts.java
@@ -47,8 +47,9 @@ public class Districts {
           District.REP_LAST_NAME + " = ?, " +
           District.REP_IMAGE_URL + " = ?, " +
           District.INFO + " = ?, " +
-          District.STATUS + " = ?," +
-          District.TIME_ZONE + " = ? " +
+          District.STATUS + " = ?, " +
+          District.TIME_ZONE + " = ?, " +
+          District.DELEGATE_SCRIPT + " = ? " +
           "WHERE " + District.DISTRICT_ID + " = ?";
 
   private static final String SQL_DELETE_DISTRICT =
@@ -162,6 +163,11 @@ public class Districts {
       District oldDistrict = retrieveDistrictById(conn, districtId);
 
       conn.setAutoCommit(false);
+
+      Boolean isIndicatingScriptDelegation = district.getDelegateScript() != null;
+      Boolean isRequestingScriptDelegation = isIndicatingScriptDelegation && district.getDelegateScript() == true;
+      Boolean delegateScript = isRequestingScriptDelegation || (!isIndicatingScriptDelegation && oldDistrict.getDelegateScript());
+
       PreparedStatement statement = conn.prepareStatement(SQL_UPDATE_DISTRICT);
       int idx = 1;
       statement.setString(idx++, district.getState());
@@ -173,6 +179,7 @@ public class Districts {
       String status = district.getStatus() == null ? null : district.getStatus().name();
       statement.setString(idx++, status);
       statement.setString(idx++, district.getTimeZone() == null ? oldDistrict.getTimeZone() : district.getTimeZone());
+      statement.setBoolean(idx++, delegateScript);
       statement.setInt(idx, districtId);
       statement.executeUpdate();
 

--- a/src/main/java/com/ccl/grandcanyon/ReminderService.java
+++ b/src/main/java/com/ccl/grandcanyon/ReminderService.java
@@ -594,8 +594,7 @@ public class ReminderService {
           District district = new District(rs);
           // send a notification if it's been > N days since script was modified and it's been greater than
           // N days since the last time we sent a notification.
-          if ((district.getScriptModifiedTime() == null || district.getScriptModifiedTime().before(staleTime)) &&
-              district.getLastStaleScriptNotification().before(staleTime)) {
+          if (district.needsStaleScriptNotification(staleTime)) {
             if (rs.getBoolean(Admin.LOGIN_ENABLED)) {
               if (sendStaleScrptNotification(district, rs.getString(Admin.EMAIL))) {
                 PreparedStatement update = conn.prepareStatement(SQL_UPDATE_STALE_SCRIPT_NOTIFICATION);

--- a/src/main/java/com/ccl/grandcanyon/types/District.java
+++ b/src/main/java/com/ccl/grandcanyon/types/District.java
@@ -25,6 +25,7 @@ public class District extends GCBase {
   public static final String LAST_STALE_SCRIPT_NOTIFICATION = "last_stale_script_notification";
   public static final String STATUS = "status";
   public static final String TIME_ZONE = "time_zone";
+  public static final String DELEGATE_SCRIPT = "delegate_script";
 
   private int districtId;
   private String state;
@@ -37,6 +38,7 @@ public class District extends GCBase {
   private Timestamp lastStaleScriptNotification;
   private Status status;
   private String timezone;
+  private Boolean delegateScript;
 
   private String info;
 
@@ -59,6 +61,7 @@ public class District extends GCBase {
     this.callTargets = new ArrayList<>();
     this.status = Status.valueOf(rs.getString(STATUS));
     this.timezone = rs.getString(TIME_ZONE);
+    this.delegateScript = rs.getBoolean(DELEGATE_SCRIPT);
 
     boolean retrieveCallTargets = false;
     ResultSetMetaData metaData = rs.getMetaData();
@@ -185,6 +188,14 @@ public class District extends GCBase {
   }
 
   public void setTimeZone(String timezone) { this.timezone = timezone; }
+
+  public Boolean getDelegateScript() {
+    return delegateScript;
+  }
+
+  public void setDelegateScript(Boolean delegateScript) {
+    this.delegateScript = delegateScript;
+  }
 
   public String readableName() {
     switch (this.getNumber()){

--- a/src/main/java/com/ccl/grandcanyon/types/District.java
+++ b/src/main/java/com/ccl/grandcanyon/types/District.java
@@ -206,6 +206,12 @@ public class District extends GCBase {
     }
   }
 
+  public Boolean needsStaleScriptNotification(Timestamp staleTime) {
+    return this.delegateScript == false && // if the script writing is delegated to CCL, then no notification is needed
+            (this.scriptModifiedTime == null || this.scriptModifiedTime.before(staleTime)) &&
+            this.getLastStaleScriptNotification().before(staleTime);
+  }
+
   public boolean isSenatorDistrict(){
     return getNumber() < 0;
   }


### PR DESCRIPTION
This originates from the desire from some admins to not deal with script writing and instead delegate script writing to ccl staff. Now they can focus on activating callers